### PR TITLE
Fix bindfs invocation when mounting shared folders

### DIFF
--- a/waydroid_helper/tools/mount_service.py
+++ b/waydroid_helper/tools/mount_service.py
@@ -38,10 +38,6 @@ class MountService(dbus.service.Object):
                 text=True,
             )
             fuse_version = fuse_version_result.stdout.splitlines()[0].split()[4]
-            if int(fuse_version.split('.')[0]) < 3:
-                nonempty_option = "-o nonempty"
-            else:
-                nonempty_option = ""
 
             command = [
                 "bindfs",
@@ -52,8 +48,11 @@ class MountService(dbus.service.Object):
                 source_str,
                 target_str,
             ]
-            if nonempty_option:
-                command.insert(1, nonempty_option)
+            if int(fuse_version.split('.')[0]) < 3:
+                command[1:1] = [
+                    "-o",
+                    "nonempty"
+                ]
 
             result = subprocess.run(
                 command,


### PR DESCRIPTION
Fixes #19, [refer to comment for details](https://github.com/ayasa520/waydroid-helper/issues/19#issuecomment-2759466009).

Thanks for the feature, it's much easier than dealing with fstab, user and group permissions, or file ACLs ❤️