### PR TITLE
Add command line argument to display version info

### DIFF
--- a/waydroid_helper/main.py
+++ b/waydroid_helper/main.py
@@ -30,8 +30,9 @@ else:
 class WaydroidHelperApplication(Adw.Application):
     """The main application singleton class."""
 
-    def __init__(self):
+    def __init__(self, version: str):
         super().__init__(application_id="com.jaoushingan.WaydroidHelper", flags=flags)
+        self.version = version
         self.create_action(
             "quit",
             lambda *_: self.quit(),  # pyright: ignore[reportUnknownArgumentType]
@@ -80,7 +81,7 @@ class WaydroidHelperApplication(Adw.Application):
             application_name="waydroid-helper",
             application_icon="com.jaoushingan.WaydroidHelper",
             developer_name="rikka",
-            version="0.1.2",
+            version=self.version,
             developers=["rikka"],
             copyright="© 2024 rikka",
         )
@@ -116,5 +117,5 @@ def main(version: str):
     asyncio.set_event_loop_policy(
         GLibEventLoopPolicy()  # pyright:ignore[reportUnknownArgumentType]
     )
-    app = WaydroidHelperApplication()
+    app = WaydroidHelperApplication(version)
     return app.run(sys.argv)

--- a/waydroid_helper/waydroid-helper.in
+++ b/waydroid_helper/waydroid-helper.in
@@ -72,6 +72,7 @@ if __name__ == '__main__':
     parser = ArgumentParser()
     parser.add_argument("--start-mount", action="store_true", help="Start the mounting service")
     parser.add_argument("--start-monitor", action="store_true", help="Start the monitoring service")
+    parser.add_argument("--version", action="version", version=f"%(prog)s {VERSION}")
     args = parser.parse_args()
 
     if args.start_mount:


### PR DESCRIPTION
- Add "--version" command line argument to display version string of waydroid-helper
- Reduce repetitive hardcoded values of version string, using the version string already being passed to `main.main(version)`